### PR TITLE
Added screenshot support for Rigol DL3000 series programmable DC load

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,7 @@ libapp_a_SOURCES = options.c \
                    plugins/screenshot_rigol-1000z.c \
                    plugins/screenshot_rigol-2000.c \
                    plugins/screenshot_rigol-dg4000.c \
+                   plugins/screenshot_rigol-dl3000.c \
                    plugins/screenshot_rigol-dm3068.c \
                    plugins/screenshot_rigol-dp800.c \
                    plugins/screenshot_rigol-dsa.c \

--- a/src/plugins/screenshot_rigol-dg4000.c
+++ b/src/plugins/screenshot_rigol-dg4000.c
@@ -87,7 +87,7 @@ int rigol_dg4000_screenshot(char *address, int timeout)
 struct screenshot_plugin rigol_dg4000 =
 {
     .name = "rigol-dg4000",
-    .description = "Rigol DG 4000 series function generator",
-    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DG4...",
+    .description = "Rigol DG 4000 & 1000Z series function generator",
+    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DG4... DG1...Z",
     .screenshot = rigol_dg4000_screenshot
 };

--- a/src/plugins/screenshot_rigol-dl3000.c
+++ b/src/plugins/screenshot_rigol-dl3000.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017  Martin Lund, 2020 Heiko Jakob
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include <lxi.h>
+#include "error.h"
+#include "screenshot.h"
+
+#define IMAGE_SIZE_MAX 0x400000 // 4 MB
+
+int rigol_dl3000_screenshot(char *address, int timeout)
+{
+    char response[IMAGE_SIZE_MAX];
+    char *command, *image;
+    int device, length, n;
+    char c;
+
+    // Connect to LXI instrument
+    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    if (device == LXI_ERROR)
+    {
+        error_printf("Failed to connect\n");
+        return 1;
+    }
+
+    // Send SCPI command to grab BMP image
+    command = ":PROJ:WND:DATA?";
+    lxi_send(device, command, strlen(command), timeout);
+    length = lxi_receive(device, response, IMAGE_SIZE_MAX, timeout);
+    if (length < 0)
+    {
+        error_printf("Failed to receive message\n");
+        return 1;
+    }
+
+    // Strip TMC block header
+    c = response[1];
+    n = atoi(&c);
+    image = &response[0];
+    image += n+2;
+    length -= n+2;
+
+    // Dump remaining BMP image data to file
+    screenshot_file_dump(image, length, "bmp");
+
+    // Disconnect
+    lxi_disconnect(device);
+
+    return 0;
+}
+
+// Screenshot plugin configuration
+struct screenshot_plugin rigol_dl3000 =
+{
+    .name = "rigol-dl3000",
+    .description = "Rigol DL3000 Series Programmable DC Electronic Load",
+    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DL30..",
+    .screenshot = rigol_dl3000_screenshot
+};

--- a/src/screenshot.c
+++ b/src/screenshot.c
@@ -50,6 +50,7 @@ extern struct screenshot_plugin keysight_ivx;
 extern struct screenshot_plugin rigol_1000z;
 extern struct screenshot_plugin rigol_2000;
 extern struct screenshot_plugin rigol_dg4000;
+extern struct screenshot_plugin rigol_dl3000;
 extern struct screenshot_plugin rigol_dm3068;
 extern struct screenshot_plugin rigol_dp800;
 extern struct screenshot_plugin rigol_dsa;
@@ -251,6 +252,7 @@ void screenshot_register_plugins(void)
     screenshot_plugin_register(&rigol_1000z);
     screenshot_plugin_register(&rigol_2000);
     screenshot_plugin_register(&rigol_dg4000);
+    screenshot_plugin_register(&rigol_dl3000);
     screenshot_plugin_register(&rigol_dm3068);
     screenshot_plugin_register(&rigol_dp800);
     screenshot_plugin_register(&rigol_dsa);


### PR DESCRIPTION
Added screeenshot support for Rigol DL3000 series programmable DC load and DG1000Z function generator. Code for DG3000 series is almost only a copy of the DP800 screenshot code beside the remote call to the device and the regex. Code for DG1000Z is only a change of the Regex for the DG4000 to also accept DG1000Z devices.