### PR TITLE
Added Tek MDO3024, 4 Series and 5 Series as compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ instruments:
 | Siglent Technologies SPD3303X-E   | [scpi]                     |
 | Siglent Technologies SSA3032X     | [discover+scpi+screenshot] |
 | Tektronix TDS3034B                | [discover+scpi+screenshot] |
+| Tektronix MDO3024                 | [discover+scpi]            |
+| Tektronix 4 Series MSO            | [discover+scpi]            |
+| Tektronix 5 Series MSO            | [discover+scpi]            |
 
 Note: Feel free to add your instrument(s) to the list via GitHub pull request
 or simply create a GitHub issue reporting your instrument(s) and which features


### PR DESCRIPTION
Tested 3 Tektronix oscilloscopes. LXI discover and SCPI ok.