### PR TITLE
DS1074Z+ : not functional

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ instruments:
 | Rigol Technologies DP832          | [discover+scpi+screenshot] |
 | Rigol Technologies DM3058         | [discover+scpi]            |
 | Rigol Technologies DM3068         | [discover+scpi+screenshot] |
+| Rigol Technologies DS1074Z+       | DRM-locked (LAN feature)   |
 | Rigol Technologies DS1104Z        | [discover+scpi+screenshot] |
 | Rigol Technologies DS2302         | [discover+scpi+screenshot] |
 | Rigol Technologies DSA815         | [discover+scpi+screenshot] |


### PR DESCRIPTION
Acquired a unit from a seller claiming all features were enabled.

This was not the case, successful communication occurs but there is no response to the LXI READ after the WRITE and the unit displays an error on its screen: "LAN unused, set it in RemoteIO" yet this is not possible (all options in the RemoteIO menu are disabled). Furthermore, the "Installed" menu does not show a LAN feature, leading me to believe the model is sold without this functionality (ie. functionality is DRM disabled).

Therefore, to save anyone else time, I strongly suggest listing this model as not functional.

I will be trying a Siglent next and send another report when tested.