### PR TITLE
Updated rigol-2000 plugin to allow screenshot capture on MSO5000

### DIFF
--- a/src/plugins/screenshot_rigol-2000.c
+++ b/src/plugins/screenshot_rigol-2000.c
@@ -102,6 +102,6 @@ struct screenshot_plugin rigol_2000 =
 {
     .name = "rigol-2000",
     .description = "Rigol DS/MSO 2000 series oscilloscope",
-    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DS2... MSO2...",
+    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DS2... MSO2... MSO5...",
     .screenshot = rigol_2000_screenshot
 };


### PR DESCRIPTION
Small change to screenshot_rigol-2000.c to allow this plugin to be automatically selected when capturing a screenshot from a Rigol MSO5000 oscilloscope. The rigol-1000-plugin which currently gets auto-selected causes a 'Failure handling image format' error in lxi-gui.
