### PR TITLE
fix convert to ico file in windows

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -113,12 +113,12 @@ if enable_gui
     ]
 
   if(build_machine.system() == 'cygwin')
-    convert = find_program('/ucrt64/bin/convert', required: true)
+    magick = find_program('magick', required: true)
     # Add icon in  exe
     lxi_tools_icon = custom_target('icon',
       input : '../data/icons/hicolor/scalable/apps/io.github.lxi-tools.lxi-gui.svg',
       output : 'lxi-tools.ico',
-      command : [convert, '-density', '128x128','-background', 'transparent', '@INPUT@', '@OUTPUT@'])
+      command : [magick, 'convert' , '-density', '128x128','-background', 'transparent', '@INPUT@', '@OUTPUT@'])
     lxi_gui_sources += lxi_tools_icon
     windows = import('windows')
     lxi_gui_sources += windows.compile_resources('lxi-tools.rc')


### PR DESCRIPTION
@lundmar  As I remember you suggested this in past.
 
I think we are now in good condition with windows build.

minor issue persist:
. font size
- logo in gui. I check in inkscape for windows and is the same picture as in windows version of lxi-tools


Just to inform you. Gtk works ok now and picture  refreshed ok in gtk4 4.16.4+