### PR TITLE
Correctly handle bmp screenshots with Rigol DS7000, MSO7000, MSO8000

### DIFF
--- a/src/plugins/screenshot_rigol-2000.c
+++ b/src/plugins/screenshot_rigol-2000.c
@@ -102,6 +102,6 @@ struct screenshot_plugin rigol_2000 =
 {
     .name = "rigol-2000",
     .description = "Rigol DS/MSO 2000/4000/5000 series oscilloscope",
-    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DS2... MSO2... DS4... MSO4... MSO5...",
+    .regex = "RIGOL TECHNOLOGIES Rigol Technologies DS2... MSO2... DS4... MSO4... MSO5... DS7... MSO7... MSO8...",
     .screenshot = rigol_2000_screenshot
 };


### PR DESCRIPTION
Following from #102.

Allows automatic screenshot handling to resolve the correct screenshot plugin for bitmap screen captures.

DS/MSO7k programming manual was used to confirm identical behaviour as MSO8k series.