### PR TITLE
fix opacity of screenshot picture, button stop changed to red color

### DIFF
--- a/src/lxi_gui-window.ui
+++ b/src/lxi_gui-window.ui
@@ -1342,11 +1342,11 @@
                                             <child>
                                               <object class="GtkButton">
                                                 <property name="label" translatable="1">Stop</property>
+                                                <property name="name">lxi-stop-button</property>
                                                 <property name="tooltip-text" translatable="1">Stop running script</property>
                                                 <signal name="clicked" handler="button_clicked_script_stop" swapped="yes"/>
                                                 <style>
                                                   <class name="text-button"/>
-                                                  <class name="destructive-action"/>
                                                 </style>
                                               </object>
                                             </child>

--- a/src/lxi_gui.css
+++ b/src/lxi_gui.css
@@ -1,3 +1,7 @@
+picture:disabled {
+  opacity: 1;
+}
+
 /* Application Window */
 #button-add-instrument {
   margin-left: 2px;
@@ -87,3 +91,9 @@
 .text-view-script-status text {
   background-color: rgba(0,0,0,0);
 }
+
+#lxi-stop-button {
+  background-color: var(--accent-red);
+  color: #ffffff;
+}
+


### PR DESCRIPTION
@lundmar 
I sync themes to be the same across platforms including snap package(no more orange color).
Did you have time to check PR on liblxi from last week