### PR TITLE
[RFC] adding --raw option for screenshots and adding generic plugins for png and bmp

### DIFF
--- a/man/lxi.1.in
+++ b/man/lxi.1.in
@@ -119,6 +119,10 @@ If this option is omitted the tool will automatically try to select the most sui
 List available screenshot plugins
 
 .TP
+.B \-r, \--raw
+Use raw/TCP protocol
+
+.TP
 To write screenshot image to stdout simply use '-' as the output filename.
 
 .SH "BENCHMARK OPTIONS"

--- a/src/bash-completion/lxi
+++ b/src/bash-completion/lxi
@@ -33,7 +33,8 @@ _lxi()
     screenshot_opts="-a --address \
                      -t --timeout \
                      -p --plugin \
-                     -l --list"
+                     -l --list \
+                     -r --raw"
 
     benchmark_opts="-a --address \
                     -p --port \

--- a/src/lxi_gui-window.c
+++ b/src/lxi_gui-window.c
@@ -1251,7 +1251,7 @@ static bool grab_screenshot(LxiGuiWindow *self)
     self->plugin_name = NULL;
     // Capture screenshot
     g_mutex_lock(&self->mutex_connection);
-    status = screenshot((char *)self->ip, self->plugin_name, filename, timeout, false, self->image_buffer, &(self->image_size), self->image_format, self->image_filename);
+    status = screenshot((char *)self->ip, self->port, self->protocol, self->plugin_name, filename, timeout, false, self->image_buffer, &(self->image_size), self->image_format, self->image_filename);
     g_mutex_unlock(&self->mutex_connection);
     if (status != 0)
     {
@@ -1397,7 +1397,7 @@ static gpointer live_view_worker_thread(gpointer data)
     }
     self->plugin_name = NULL;
     g_mutex_lock(&self->mutex_connection);
-    self->plugin_name = screenshot_detect_plugin_name((char *)self->ip, timeout);
+    self->plugin_name = screenshot_detect_plugin_name((char *)self->ip, self->port, self->protocol, timeout);
     g_mutex_unlock(&self->mutex_connection);
     if(self->plugin_name == NULL)
     {
@@ -1418,7 +1418,7 @@ static gpointer live_view_worker_thread(gpointer data)
             g_mutex_unlock(&self->mutex_connection);
             break;
         }
-        status = screenshot((char *)self->ip, self->plugin_name, filename, timeout, false, self->image_buffer, &(self->image_size), self->image_format, self->image_filename);
+        status = screenshot((char *)self->ip, self->port, self->protocol, self->plugin_name, filename, timeout, false, self->image_buffer, &(self->image_size), self->image_format, self->image_filename);
         if (status != 0)
         {
             show_error(self, "Live view: Failed to grab screenshot");

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
                 screenshot_list_plugins();
                 return EXIT_SUCCESS;
             }
-            status = screenshot(option.ip, option.plugin_name, option.screenshot_filename, option.timeout, true, NULL, NULL, NULL, NULL);
+            status = screenshot(option.ip, option.port, option.protocol, option.plugin_name, option.screenshot_filename, option.timeout, true, NULL, NULL, NULL, NULL);
             break;
         case BENCHMARK:
             status = benchmark(option.ip, option.port, option.timeout, option.protocol, option.count, true, &result, NULL);

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,8 @@ common_sources = [
   'lxilua.c',
   'misc.c',
   'screenshot.c',
+  'plugins/screenshot_generic-bmp.c',
+  'plugins/screenshot_generic-png.c',
   'plugins/screenshot_keysight-dmm.c',
   'plugins/screenshot_keysight-psa.c',
   'plugins/screenshot_keysight-pxa.c',

--- a/src/options.c
+++ b/src/options.c
@@ -99,6 +99,7 @@ void print_help(char *argv[])
     printf("  -t, --timeout <seconds>              Timeout (default: %d)\n", TIMEOUT_SCREENSHOT);
     printf("  -p, --plugin <name>                  Use screenshot plugin by name\n");
     printf("  -l, --list                           List available screenshot plugins\n");
+    printf("  -r, --raw                            Use raw/TCP\n");
     printf("\n");
     printf("Benchmark options:\n");
     printf("  -a, --address <ip>                   Device IP address\n");
@@ -236,13 +237,14 @@ void parse_options(int argc, char *argv[])
             {"timeout",        required_argument, 0, 't'},
             {"plugin",         required_argument, 0, 'p'},
             {"list",           no_argument,       0, 'l'},
+            {"raw",            no_argument,       0, 'r'},
             {0,                0,                 0,  0 }
         };
 
         do
         {
             /* Parse screenshot options */
-            c = getopt_long(argc, argv, "a:t:p:l", long_options, &option_index);
+            c = getopt_long(argc, argv, "a:t:p:lr", long_options, &option_index);
 
             switch (c)
             {
@@ -260,6 +262,10 @@ void parse_options(int argc, char *argv[])
 
                 case 'l':
                     option.list = true;
+                    break;
+
+                case 'r':
+                    option.protocol = RAW;
                     break;
 
                 case '?':

--- a/src/plugins/screenshot_generic-bmp.c
+++ b/src/plugins/screenshot_generic-bmp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023  Martin Lund
+ * Copyright (c) 2025  Darius Vozbutas
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,9 +38,9 @@
 #include "error.h"
 #include "screenshot.h"
 
-#define IMAGE_SIZE_MAX 0x800000 // 8 MB
+#define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int tektronix_screenshot_mso_5(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
+int generic_bmp_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -56,28 +56,22 @@ int tektronix_screenshot_mso_5(char *address, int port, lxi_protocol_t protocol,
         goto error_connect;
     }
 
-    // Send SCPI commands to grab PNG image
-    command = "SAVE:IMAGE 'c:/lxi-tools-screenshot.png'";
-    lxi_send(device, command, strlen(command), timeout);
-    command = "*WAI";
-    lxi_send(device, command, strlen(command), timeout);
-    command = "FILESYSTEM:READFILE 'c:/lxi-tools-screenshot.png'";
-    lxi_send(device, command, strlen(command), timeout);
+    // Send SCPI command to grab BMP image
+    command = "display:data?";
+    if (protocol == RAW)
+        command = "display:data?\n";
+
+    length = lxi_send(device, command, strlen(command), timeout);
     length = lxi_receive(device, response, IMAGE_SIZE_MAX, timeout);
-    if (length < 0)
+
+    if (length <= 0)
     {
         error_printf("Failed to receive message\n");
         goto error_receive;
     }
 
-    // Cleanup
-    command = "FILESystem:DELEte 'c:/lxi-tools-screenshot.png'";
-    lxi_send(device, command, strlen(command), timeout);
-    command = "*WAI";
-    lxi_send(device, command, strlen(command), timeout);
-
-    // Dump PNG image data to file
-    screenshot_file_dump(response, length, "png");
+    // Dump remaining BMP image data to file
+    screenshot_file_dump(response, length, "bmp");
 
     // Free allocated memory for screenshot
     free(response);
@@ -96,12 +90,11 @@ error_receive:
     return 1;
 }
 
-
 // Screenshot plugin configuration
-struct screenshot_plugin tektronix_mso_5 =
+struct screenshot_plugin generic_bmp =
 {
-    .name = "tektronix-mso-5",
-    .description = "Tektronix MSO 5 series oscilloscope",
-    .regex = "TEKTRONIX MSO5...",
-    .screenshot = tektronix_screenshot_mso_5
+    .name = "generic-bmp",
+    .description = "for manufacturers that provide compatibility with lxi-tools",
+    .regex = "lxi-tools/bmp",
+    .screenshot = generic_bmp_screenshot
 };

--- a/src/plugins/screenshot_generic-bmp.c
+++ b/src/plugins/screenshot_generic-bmp.c
@@ -57,9 +57,9 @@ int generic_bmp_screenshot(char *address, int port, lxi_protocol_t protocol, cha
     }
 
     // Send SCPI command to grab BMP image
-    command = "display:data?";
+    command = "display:data? BMP";
     if (protocol == RAW)
-        command = "display:data?\n";
+        command = "display:data? BMP\n";
 
     length = lxi_send(device, command, strlen(command), timeout);
     length = lxi_receive(device, response, IMAGE_SIZE_MAX, timeout);

--- a/src/plugins/screenshot_generic-png.c
+++ b/src/plugins/screenshot_generic-png.c
@@ -57,9 +57,9 @@ int generic_png_screenshot(char *address, int port, lxi_protocol_t protocol, cha
     }
 
     // Send SCPI command to grab PNG image
-    command = "display:data?";
+    command = "display:data? PNG";
     if (protocol == RAW)
-        command = "display:data?\n";
+        command = "display:data? PNG\n";
 
     length = lxi_send(device, command, strlen(command), timeout);
     length = lxi_receive(device, response, IMAGE_SIZE_MAX, timeout);

--- a/src/plugins/screenshot_keysight-dmm.c
+++ b/src/plugins/screenshot_keysight-dmm.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int keysight_dmm_screenshot(char *address, char *id, int timeout)
+int keysight_dmm_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int keysight_dmm_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_keysight-dso.c
+++ b/src/plugins/screenshot_keysight-dso.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int keysight_dso_screenshot(char *address, char *id, int timeout)
+int keysight_dso_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int keysight_dso_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_keysight-ivx.c
+++ b/src/plugins/screenshot_keysight-ivx.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int keysight_ivx_screenshot(char *address, char *id, int timeout)
+int keysight_ivx_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int keysight_ivx_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_keysight-psa.c
+++ b/src/plugins/screenshot_keysight-psa.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int keysight_psa_screenshot(char *address, char *id, int timeout)
+int keysight_psa_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int keysight_psa_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_keysight-pxa.c
+++ b/src/plugins/screenshot_keysight-pxa.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int keysight_pxa_screenshot(char *address, char *id, int timeout)
+int keysight_pxa_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int keysight_pxa_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_lecroy.c
+++ b/src/plugins/screenshot_lecroy.c
@@ -68,7 +68,7 @@ static int scdp_status_wait(int device, int timeout)
     return 1;
 }
 
-int lecroy_screenshot(char *address, char *id, int timeout)
+int lecroy_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     UNUSED(id);
 
@@ -80,7 +80,7 @@ int lecroy_screenshot(char *address, char *id, int timeout)
         return 1;
     }
 
-    int device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    int device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-1000z.c
+++ b/src/plugins/screenshot_rigol-1000z.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_1000z_screenshot(char *address, char *id, int timeout)
+int rigol_1000z_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_1000z_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-2000.c
+++ b/src/plugins/screenshot_rigol-2000.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_2000_screenshot(char *address, char *id, int timeout)
+int rigol_2000_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_2000_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-dg.c
+++ b/src/plugins/screenshot_rigol-dg.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_dg_screenshot(char *address, char *id, int timeout)
+int rigol_dg_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_dg_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-dl3000.c
+++ b/src/plugins/screenshot_rigol-dl3000.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_dl3000_screenshot(char *address, char *id, int timeout)
+int rigol_dl3000_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_dl3000_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-dm3068.c
+++ b/src/plugins/screenshot_rigol-dm3068.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_dm3068_screenshot(char *address, char *id, int timeout)
+int rigol_dm3068_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_dm3068_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-dp800.c
+++ b/src/plugins/screenshot_rigol-dp800.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_dp800_screenshot(char *address, char *id, int timeout)
+int rigol_dp800_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_dp800_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rigol-dsa.c
+++ b/src/plugins/screenshot_rigol-dsa.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int rigol_dsa_screenshot(char *address, char *id, int timeout)
+int rigol_dsa_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command, *image;
@@ -50,7 +50,7 @@ int rigol_dsa_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rohde-schwarz-fsv.c
+++ b/src/plugins/screenshot_rohde-schwarz-fsv.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x100000 * 20 // 20 MB
 
-int rs_fsv_screenshot(char *address, char *id, int timeout)
+int rs_fsv_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char *command, *image;
     int device, length, n;
@@ -57,7 +57,7 @@ int rs_fsv_screenshot(char *address, char *id, int timeout)
     }
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rohde-schwarz-hmo-rtb.c
+++ b/src/plugins/screenshot_rohde-schwarz-hmo-rtb.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x100000 * 20 // 20 MB
 
-int rs_hmo_rtb_screenshot(char *address, char *id, int timeout)
+int rs_hmo_rtb_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char *command, *image;
     int device, length, n;
@@ -57,7 +57,7 @@ int rs_hmo_rtb_screenshot(char *address, char *id, int timeout)
     }
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rohde-schwarz-ng.c
+++ b/src/plugins/screenshot_rohde-schwarz-ng.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x100000 * 20 // 20 MB
 
-int rs_ng_screenshot(char *address, char *id, int timeout)
+int rs_ng_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char *command, *image;
     int device, length, n;
@@ -57,7 +57,7 @@ int rs_ng_screenshot(char *address, char *id, int timeout)
     }
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_rohde-schwarz-rth.c
+++ b/src/plugins/screenshot_rohde-schwarz-rth.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x100000 * 20 // 20 MB
 
-int rs_rth_screenshot(char *address, char *id, int timeout)
+int rs_rth_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char *command, *image;
     int device, length, n;
@@ -57,7 +57,7 @@ int rs_rth_screenshot(char *address, char *id, int timeout)
     }
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_siglent-sdg.c
+++ b/src/plugins/screenshot_siglent-sdg.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int siglent_sdg_screenshot(char *address, char *id, int timeout)
+int siglent_sdg_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -49,7 +49,7 @@ int siglent_sdg_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_siglent-sdm3000.c
+++ b/src/plugins/screenshot_siglent-sdm3000.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int siglent_sdm3000_screenshot(char *address, char *id, int timeout)
+int siglent_sdm3000_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -49,7 +49,7 @@ int siglent_sdm3000_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_siglent-sds.c
+++ b/src/plugins/screenshot_siglent-sds.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int siglent_sds_screenshot(char *address, char *id, int timeout)
+int siglent_sds_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -49,7 +49,7 @@ int siglent_sds_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_siglent-ssa3000x.c
+++ b/src/plugins/screenshot_siglent-ssa3000x.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int siglent_ssa3000x_screenshot(char *address, char *id, int timeout)
+int siglent_ssa3000x_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -49,7 +49,7 @@ int siglent_ssa3000x_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_tektronix-3000.c
+++ b/src/plugins/screenshot_tektronix-3000.c
@@ -51,7 +51,7 @@ typedef struct{
 
 void length_check(int length);
 
-int tektronix_screenshot_3000(char *address, char *id, int timeout)
+int tektronix_screenshot_3000(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     restore param;
     char* response = malloc(IMAGE_SIZE_MAX);
@@ -61,7 +61,7 @@ int tektronix_screenshot_3000(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/plugins/screenshot_tektronix.c
+++ b/src/plugins/screenshot_tektronix.c
@@ -40,7 +40,7 @@
 
 #define IMAGE_SIZE_MAX 0x400000 // 4 MB
 
-int tektronix_screenshot(char *address, char *id, int timeout)
+int tektronix_screenshot(char *address, int port, lxi_protocol_t protocol, char *id, int timeout)
 {
     char* response = malloc(IMAGE_SIZE_MAX);
     char *command;
@@ -49,7 +49,7 @@ int tektronix_screenshot(char *address, char *id, int timeout)
     UNUSED(id);
 
     // Connect to LXI instrument
-    device = lxi_connect(address, 0, NULL, timeout, VXI11);
+    device = lxi_connect(address, port, NULL, timeout, protocol);
     if (device == LXI_ERROR)
     {
         error_printf("Failed to connect\n");

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -36,10 +36,12 @@ extern "C" {
 
 #include <stdbool.h>
 #include "misc.h"
+#include <lxi.h>
 
 void screenshot_register_plugins(void);
 void screenshot_list_plugins(void);
-int screenshot(char *address, char *plugin_name, char *filename,
+int screenshot(char *address, int port, lxi_protocol_t protocol,
+               char *plugin_name, char *filename,
                int timeout, bool no_gui, void *image_buffer,
                int *image_size, char *image_format, char *image_filename);
 
@@ -51,10 +53,10 @@ struct screenshot_plugin
    const char *name;
    const char *description;
    const char *regex;
-   int (*screenshot)(char *address, char *id, int timeout);
+   int (*screenshot)(char *address, int port, lxi_protocol_t protocol, char *id, int timeout);
 };
 
-char* screenshot_detect_plugin_name(char *address, int timeout);
+char* screenshot_detect_plugin_name(char *address, int port, lxi_protocol_t protocol, int timeout);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Request For Comments

It's kinda two things in same PR but i could not test one without the other, so together they go.

1. Added --raw option for screenshots just like scpi and benchmark already has.
  * had to modify all plugins and screenshots and gui as i needed to propagate port and protocol everywhere
  * would like to add --port too, but screenshots already has -p used up for --plugin and I would like consistency with other commands. maybe give plugin some other short arg like -d / --device ?
 
2. Added generic screenshot plugins for png and bmp. let me know if you want other keywords or command.
  * `.regex = "lxi-tools/bmp"` and `.regex = "lxi-tools/png"`
  * `command = "display:data? BMP\n";` and `command = "display:data? PNG\n";`

3. Testing
  * new generic plugins works
  * `rigol-1000z` and `siglent-sdg` still works too
  * could not test gui as i have no machine to run it, but it compiles with no errors and no extra warnings as far as i can tell.

this would solve #122 and #123 